### PR TITLE
[BUGFIX] more fallbacks if ConfigurationManager::getCurrentPageUid cant ...

### DIFF
--- a/Classes/ConfigurationManager.php
+++ b/Classes/ConfigurationManager.php
@@ -174,6 +174,16 @@ class ConfigurationManager implements \TYPO3\CMS\Core\SingletonInterface {
 			return $this->currentPageUid;
 		}
 
+		$rootPages = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('uid', 'pages', 'deleted=0 AND hidden=0 AND is_siteroot=1', '', '', '1');
+		if (count($rootPages) > 0) {
+			return $rootPages[0]['uid'];
+		}
+
+		$rootTemplates = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('pid', 'sys_template', 'deleted=0 AND hidden=0 AND root=1', '', '', '1');
+		if (count($rootTemplates) > 0) {
+			return $rootTemplates[0]['pid'];
+		}
+
 		return 0;
 	}
 


### PR DESCRIPTION
...find the current page id

I create a "Text with Picture" content and than i try to link this picture that does not work.
At the first time if the element browser pop up i see my custom tab.
But if i click the tab it disappears.
This is because the ConfigurationManager->getCurrentPageUid() can not resolve the current Page Id and
returned Zero because at this time there is no $_GET['P']['pid'] param in the URL.
But at Page Zero there is no PageTS...
I add some Fallbacks inspired by the BackendConfigurationManager from extbase

http://typo3.org/api/typo3cms/class_t_y_p_o3_1_1_c_m_s_1_1_extbase_1_1_configuration_1_1_backend_configuration_manager.html#a3bfe3452963b48e44edfe97354d74bb0
